### PR TITLE
link para "software livre"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hackatão Português para o Software Livre  
 **Único e maior evento dedicado ao Software Livre Português.**
 
-O objetivo é reunir esforços e colaborar para o desenvolvimento de software livre português. Desde empacotar software público, desenvolver código utilizável por instituições públicas, até a escrever documentação de estratégias para adoção de software livre.
+O objetivo é reunir esforços e colaborar para o desenvolvimento de software livre português. Desde empacotar software público, desenvolver código utilizável por instituições públicas, até a escrever documentação de estratégias para adoção de [software livre](https://ansol.org/filosofia).
 
 ## Como começar  
 Idealmente, é importante ver os issues que estejam sem atribuições e escolher um que desperte interesse. O propósito não é ter uma lista infindável de tarefas por fazer mas sim organizar um conjunto de tarefas de interesse público e evitar que se repitam esforços. Dessa forma, se tens alguma proposta ou se queres propor uma nova iniciativa mas precisas de ajuda:  


### PR DESCRIPTION
Porque quem lê isto pode não saber necessariamente o que é software livre, adicionei um link ao termo, a apontar para a página da ANSOL sobre o tema, que inclui a tradução portuguesa da definição oficial (ou seja, as quatro liberdades).